### PR TITLE
feat(events): add XVI Fórum Internacional de Pedagogia (XVI FIPED)

### DIFF
--- a/src/content/events/xvi-forum-internacional-de-pedagogia-xvi-fiped.md
+++ b/src/content/events/xvi-forum-internacional-de-pedagogia-xvi-fiped.md
@@ -1,0 +1,21 @@
+---
+title: "XVI Fórum Internacional de Pedagogia (XVI FIPED)"
+start_date: "2026-05-27"
+end_date: "2026-05-30"
+kind: "summit"
+format: "hybrid"
+city: "Quixadá"
+state: "CE"
+organizer: "Universidade Estadual do Ceará (UECE) e Associação Internacional de Pesquisa na Graduação em Pedagogia (AINPGP)"
+venue: "Quixadá"
+ticket_url: "https://even3.com.br/xvi-forum-internacional-de-pedagogia-xvi-fiped-625683?even3_orig=events_eventlist"
+source_name: "Even3 Eventos"
+source_url: "https://even3.com.br/xvi-forum-internacional-de-pedagogia-xvi-fiped-625683?even3_orig=events_eventlist"
+categories: 
+  - "outros"
+featured: false
+cover_image: "https://images.even3.com.br/otzZ39fC7xMZBFOW_KGhfMWiJHs=/1100x440/smart/https://static.even3.com.br/banner/WhatsAppImage2025-09-13at12.08.22.3fb33ce1dc114bc5b932.jpeg"
+price: "R$90,00"
+---
+
+O XVI Fórum Internacional de Pedagogia (XVI FIPED) ocorrerá no período de 27 a 30 de maio de 2026, em formato híbrido, na cidade de Quixadá, no Sertão Central do Ceará. O evento tem se constituído como uma experiência de luta e resistência por inclusão e diversidade na pesquisa científica. Em sintonia com o histórico do evento, o XVI FIPED objetiva o amplo debate sobre o lugar da pesquisa na graduação e a valorização do conhecimento produzido nos diversos territórios do “Brasil profundo”. À sombra da Galinha Choca e sobre a barragem do açude Cedro reúne elementos que simbolizam a resistência sertaneja, nordestina e brasileira, cenário propício a reflexões sobre a luta pelo direito a educação, a cultura e a pesquisa, a todas e todos.


### PR DESCRIPTION
## Event intake

- Fonte: [Even3 Eventos](https://even3.com.br/xvi-forum-internacional-de-pedagogia-xvi-fiped-625683?even3_orig=events_eventlist)
- Ticket URL: [https://even3.com.br/xvi-forum-internacional-de-pedagogia-xvi-fiped-625683?even3_orig=events_eventlist](https://even3.com.br/xvi-forum-internacional-de-pedagogia-xvi-fiped-625683?even3_orig=events_eventlist)
- Confianca: 100/100
- Datas: 2026-05-27 -> 2026-05-30
- Organizador: Universidade Estadual do Ceará (UECE) e Associação Internacional de Pesquisa na Graduação em Pedagogia (AINPGP)
- Categorias: `outros`

## Resumo

O XVI Fórum Internacional de Pedagogia (XVI FIPED) ocorrerá de 27 a 30 de maio de 2026, em formato híbrido, em Quixadá, Ceará. O evento foca na pesquisa na graduação, inclusão e diversidade, valorizando o conhecimento produzido em territórios diversos. Simboliza a resistência sertaneja e nordestina.

## Ambiguidades

- nenhuma

<!-- event-intake-source:f755c8f37de76234339c3b7f483b392794d1828d3908b06225590dc35e90953a -->