### PR TITLE
feat(events): add 3º Colóquio de Livros Didáticos de Matemática

### DIFF
--- a/src/content/events/3-coloquio-de-livros-didaticos-de-matematica.md
+++ b/src/content/events/3-coloquio-de-livros-didaticos-de-matematica.md
@@ -1,0 +1,21 @@
+---
+title: "3º Colóquio de Livros Didáticos de Matemática"
+start_date: "2026-09-02"
+end_date: "2026-09-04"
+kind: "other"
+format: "in-person"
+city: "Recife"
+state: "PE"
+organizer: "Universidade Federal de Pernambuco"
+venue: "Universidade Federal de Pernambuco"
+ticket_url: "https://even3.com.br/3-coloquio-de-livros-didaticos-de-matematica-691542"
+source_name: "Even3 Submissoes"
+source_url: "https://even3.com.br/3-coloquio-de-livros-didaticos-de-matematica-691542"
+categories: 
+  - "outros"
+featured: false
+cover_image: "https://images.even3.com.br/OpuqFP7FXvsL0OPMtLSoQYTHDck=/1100x440/smart/https://static.even3.com.br/banner/Designsemnome1.d45f0cbb0365482dbaaf.png"
+price: "R$40,00 (Estudante de graduação - associado/a SBEM, até 30/04/2026)"
+---
+
+O Colóquio de Livros Didáticos de Matemática (CLDM) é um evento científico dedicado à discussão e socialização de pesquisas sobre o livro didático como elemento central nos processos de ensino e aprendizagem de Matemática. Reúne pesquisadores, professores e estudantes de diferentes regiões do país para promover o diálogo entre universidade e escola, fortalecer a formação docente e ampliar o debate sobre práticas pedagógicas e políticas públicas relacionadas aos materiais didáticos.


### PR DESCRIPTION
## Event intake

- Fonte: [Even3 Submissoes](https://even3.com.br/3-coloquio-de-livros-didaticos-de-matematica-691542)
- Ticket URL: [https://even3.com.br/3-coloquio-de-livros-didaticos-de-matematica-691542](https://even3.com.br/3-coloquio-de-livros-didaticos-de-matematica-691542)
- Confianca: 100/100
- Datas: 2026-09-02 -> 2026-09-04
- Organizador: Universidade Federal de Pernambuco
- Categorias: `outros`

## Resumo

O 3º Colóquio de Livros Didáticos de Matemática (CLDM) ocorrerá de 02 a 04 de setembro de 2026 na Universidade Federal de Pernambuco (UFPE), em Recife (PE). O evento foca na discussão e socialização de pesquisas sobre o livro didático de Matemática.

## Ambiguidades

- nenhuma

<!-- event-intake-source:60f0e2ac60890a9e557a17b1e29f937876d4b56e9b4bd65d9ec6ceb2095348fc -->