### PR TITLE
feat(events): add Google I/O Extended + Build with AI 2026 - Natal

### DIFF
--- a/src/content/events/google-i-o-extended-build-with-ai-2026-natal.md
+++ b/src/content/events/google-i-o-extended-build-with-ai-2026-natal.md
@@ -1,0 +1,22 @@
+---
+title: "Google I/O Extended + Build with AI 2026 - Natal"
+start_date: "2026-06-05"
+end_date: "2026-06-06"
+kind: "conference"
+format: "in-person"
+city: "Natal"
+state: "RN"
+organizer: "Google Developer Groups"
+venue: "Sebrae"
+ticket_url: "https://gdg.community.dev/events/details/google-gdg-natal-presents-google-io-extended-build-with-ai-2026-natal"
+source_name: "GDG Natal"
+source_url: "https://gdg.community.dev/events/details/google-gdg-natal-presents-google-io-extended-build-with-ai-2026-natal"
+categories: 
+  - "ia"
+  - "cloud"
+featured: false
+cover_image: "https://res.cloudinary.com/startup-grind/image/upload/c_fill,dpr_2.0,f_auto,g_center,h_900,q_auto:good,w_1200/v1/gcs/platform-data-goog/contentbuilder/GDG_Bevy_SocialSharingThumbnail_KFxxrrs.png"
+price: ""
+---
+
+Embarque em uma jornada tecnológica no Google I/O Extended + Build with AI 2026 - Natal, um evento unificado e inovador...


### PR DESCRIPTION
## Event intake

- Fonte: [GDG Natal](https://gdg.community.dev/events/details/google-gdg-natal-presents-google-io-extended-build-with-ai-2026-natal)
- Ticket URL: [https://gdg.community.dev/events/details/google-gdg-natal-presents-google-io-extended-build-with-ai-2026-natal](https://gdg.community.dev/events/details/google-gdg-natal-presents-google-io-extended-build-with-ai-2026-natal)
- Confianca: 100/100
- Datas: 2026-06-05 -> 2026-06-06
- Organizador: Google Developer Groups
- Categorias: `ia`, `cloud`

## Resumo

Embarque em uma jornada tecnológica no Google I/O Extended + Build with AI 2026 - Natal, um evento unificado e inovador...

## Ambiguidades

- nenhuma

<!-- event-intake-source:d7dcadf3bcd2f402bea01a5934897a6f27aabd00962a745ed78a08f09c13f33d -->