### PR TITLE
feat(events): add Google I/O Extended Fortaleza

### DIFF
--- a/src/content/events/google-i-o-extended-fortaleza.md
+++ b/src/content/events/google-i-o-extended-fortaleza.md
@@ -8,15 +8,15 @@ city: "Fortaleza"
 state: "CE"
 organizer: "GDG Fortaleza"
 venue: "Auditorio Principal"
-ticket_url: "https://www.gdgfortaleza.com/eventos"
+ticket_url: "https://www.gdgfortaleza.com/eventos/8"
 source_name: "GDG Fortaleza"
-source_url: "https://www.gdgfortaleza.com/eventos"
+source_url: "https://www.gdgfortaleza.com/eventos/8"
 categories: 
   - "ia"
   - "cloud"
   - "mobile"
 featured: false
-cover_image: ""
+cover_image: "https://res.cloudinary.com/startup-grind/image/upload/c_fill,dpr_2.0,f_auto,g_center,q_auto:good/v1/gcs/platform-data-goog/events/IOE23-Bevy-Thumbnail-1080x1080-Default_IQS7B6T.png"
 price: "Gratuito"
 ---
 

--- a/src/content/events/google-i-o-extended-fortaleza.md
+++ b/src/content/events/google-i-o-extended-fortaleza.md
@@ -1,0 +1,23 @@
+---
+title: "Google I/O Extended Fortaleza"
+start_date: "2026-05-30"
+end_date: "2026-05-30"
+kind: "meetup"
+format: "in-person"
+city: "Fortaleza"
+state: "CE"
+organizer: "GDG Fortaleza"
+venue: "Auditorio Principal"
+ticket_url: "https://www.gdgfortaleza.com/eventos"
+source_name: "GDG Fortaleza"
+source_url: "https://www.gdgfortaleza.com/eventos"
+categories: 
+  - "ia"
+  - "cloud"
+  - "mobile"
+featured: false
+cover_image: ""
+price: "Gratuito"
+---
+
+Celebracao local do Google I/O organizada pelo GDG Fortaleza, com discussoes sobre novidades do ecossistema Google. O encontro aparece na agenda publica da comunidade com trilhas de IA, cloud e Android para desenvolvedores e profissionais de tecnologia.


### PR DESCRIPTION
## Event intake manual

- Acao: adicionar evento
- Fonte: [GDG Fortaleza](https://www.gdgfortaleza.com/eventos)
- Ticket URL: [https://www.gdgfortaleza.com/eventos](https://www.gdgfortaleza.com/eventos)
- Confianca: 100/100
- Categorias: `ia`, `cloud`, `mobile`
- Arquivo: `src/content/events/google-i-o-extended-fortaleza.md`

## Validacao

- Fonte publica informada no payload manual
- Evento marcado como tech direto
- Schema normalizado para o modelo editorial atual

<!-- event-intake-source:https://www.gdgfortaleza.com/eventos -->