### PR TITLE
feat(events): add TDC Experience Recife | Rec’n’Play 2026

### DIFF
--- a/src/content/events/tdc-experience-recife-rec-n-play-2026.md
+++ b/src/content/events/tdc-experience-recife-rec-n-play-2026.md
@@ -1,0 +1,24 @@
+---
+title: "TDC Experience Recife | Rec’n’Play 2026"
+start_date: "2026-11-11"
+end_date: "2026-11-12"
+kind: "conference"
+format: "in-person"
+city: "Recife"
+state: "PE"
+organizer: "The Developer's Conference"
+venue: "Moinho Recife"
+ticket_url: "https://thedevconf.com/tdc/2026/datas-e-locais"
+source_name: "The Developer's Conference"
+source_url: "https://thedevconf.com/tdc/2026/datas-e-locais"
+categories: 
+  - "fullstack"
+  - "backend"
+  - "frontend"
+  - "ia"
+featured: false
+cover_image: ""
+price: ""
+---
+
+Edicao Recife do The Developer's Conference dentro do Rec’n’Play, confirmada para 11 e 12 de novembro no Moinho Recife. O TDC e uma conferencia nacional voltada a desenvolvimento de software, comunidades tecnicas, produto, dados e tendencias de tecnologia.

--- a/src/content/events/tdc-experience-recife-rec-n-play-2026.md
+++ b/src/content/events/tdc-experience-recife-rec-n-play-2026.md
@@ -8,16 +8,16 @@ city: "Recife"
 state: "PE"
 organizer: "The Developer's Conference"
 venue: "Moinho Recife"
-ticket_url: "https://thedevconf.com/tdc/2026/datas-e-locais"
+ticket_url: "https://thedevconf.com/tdc/2026/stage/recife/"
 source_name: "The Developer's Conference"
-source_url: "https://thedevconf.com/tdc/2026/datas-e-locais"
+source_url: "https://thedevconf.com/tdc/2026/stage/recife/"
 categories: 
   - "fullstack"
   - "backend"
   - "frontend"
   - "ia"
 featured: false
-cover_image: ""
+cover_image: "https://cdn.thedevconf.com.br/2026/img/site/StageBoldRecWth.png"
 price: ""
 ---
 


### PR DESCRIPTION
## Event intake manual

- Acao: adicionar evento
- Fonte: [The Developer's Conference](https://thedevconf.com/tdc/2026/datas-e-locais)
- Ticket URL: [https://thedevconf.com/tdc/2026/datas-e-locais](https://thedevconf.com/tdc/2026/datas-e-locais)
- Confianca: 100/100
- Categorias: `fullstack`, `backend`, `frontend`, `ia`
- Arquivo: `src/content/events/tdc-experience-recife-rec-n-play-2026.md`

## Validacao

- Fonte publica informada no payload manual
- Evento marcado como tech direto
- Schema normalizado para o modelo editorial atual

<!-- event-intake-source:https://thedevconf.com/tdc/2026/datas-e-locais -->