### PR TITLE
feat(events): add DevOpsDays Recife 2026

### DIFF
--- a/src/content/events/devopsdays-recife-2026.md
+++ b/src/content/events/devopsdays-recife-2026.md
@@ -1,0 +1,22 @@
+---
+title: "DevOpsDays Recife 2026"
+start_date: "2026-12-12"
+end_date: "2026-12-12"
+kind: "conference"
+format: "in-person"
+city: "Recife"
+state: "PE"
+organizer: "DevOpsDays"
+venue: "Recife"
+ticket_url: "https://talks.devopsdays.org/devopsdays-recife-2026"
+source_name: "DevOpsDays Talks"
+source_url: "https://talks.devopsdays.org/devopsdays-recife-2026"
+categories: 
+  - "devops"
+  - "cloud"
+featured: false
+cover_image: ""
+price: ""
+---
+
+Edicao Recife 2026 do DevOpsDays, listada na plataforma oficial de chamadas da comunidade. O evento integra o calendario global DevOpsDays e e direcionado a profissionais de desenvolvimento, operacoes, plataforma, infraestrutura e cultura DevOps.

--- a/src/content/events/devopsdays-recife-2026.md
+++ b/src/content/events/devopsdays-recife-2026.md
@@ -8,15 +8,20 @@ city: "Recife"
 state: "PE"
 organizer: "DevOpsDays"
 venue: "Recife"
-ticket_url: "https://talks.devopsdays.org/devopsdays-recife-2026"
+ticket_url: "https://devopsdays.org/events/2026-recife/welcome/"
 source_name: "DevOpsDays Talks"
-source_url: "https://talks.devopsdays.org/devopsdays-recife-2026"
+source_url: "https://devopsdays.org/events/2026-recife/welcome/"
 categories: 
   - "devops"
   - "cloud"
 featured: false
-cover_image: ""
+cover_image: "https://devopsdays.org/events/2026-recife/logo_hu_2156f1783058e197.webp"
 price: ""
 ---
 
-Edicao Recife 2026 do DevOpsDays, listada na plataforma oficial de chamadas da comunidade. O evento integra o calendario global DevOpsDays e e direcionado a profissionais de desenvolvimento, operacoes, plataforma, infraestrutura e cultura DevOps.
+DEVOPSDAYS RECIFE - 2026
+É com grande entusiasmo que convidamos você para a sexta edição do DevOpsDays Recife, em dezembro de 2026, em Recife (Pernambuco). Como organizadores, queremos reunir de novo entusiastas, profissionais e especialistas do ecossistema DevOps para um encontro enriquecedor e inspirador — com gente de todo o Nordeste e de qualquer lugar do Brasil.
+
+Se você é desenvolvedor, sysadmin, SRE, gerente de produto ou projetos, trabalha com plataforma, segurança ou é simplesmente curioso, está convidado! O DevOpsDays Recife é o lugar para trocar ideias, aprender, se conectar com várias pessoas e com a comunidade tech.
+
+O local do evento ainda será divulgado; acompanhe este site e nossas redes para CFP, inscrições e novidades. Esperamos você para explorar e fortalecer a nossa comunidade.


### PR DESCRIPTION
## Event intake manual

- Acao: adicionar evento
- Fonte: [DevOpsDays Talks](https://talks.devopsdays.org/devopsdays-recife-2026)
- Ticket URL: [https://talks.devopsdays.org/devopsdays-recife-2026](https://talks.devopsdays.org/devopsdays-recife-2026)
- Confianca: 100/100
- Categorias: `devops`, `cloud`
- Arquivo: `src/content/events/devopsdays-recife-2026.md`

## Validacao

- Fonte publica informada no payload manual
- Evento marcado como tech direto
- Schema normalizado para o modelo editorial atual

<!-- event-intake-source:https://talks.devopsdays.org/devopsdays-recife-2026 -->