### PR TITLE
feat(events): add Build With AI: Hands-on Codelab Experience

### DIFF
--- a/src/content/events/build-with-ai-hands-on-codelab-experience.md
+++ b/src/content/events/build-with-ai-hands-on-codelab-experience.md
@@ -1,0 +1,23 @@
+---
+title: "Build With AI: Hands-on Codelab Experience"
+start_date: "2026-05-23"
+end_date: "2026-05-23"
+kind: "workshop"
+format: "in-person"
+city: "Lauro de Freitas"
+state: "BA"
+organizer: "GDG Lauro de Freitas"
+venue: "SENAI Lauro de Freitas"
+ticket_url: "https://gdg.community.dev/events/details/google-gdg-lauro-de-freitas-presents-build-with-ai-hands-on-codelab-experience"
+source_name: "GDG Lauro de Freitas"
+source_url: "https://gdg.community.dev/events/details/google-gdg-lauro-de-freitas-presents-build-with-ai-hands-on-codelab-experience"
+categories: 
+  - "ia"
+  - "cloud"
+  - "ux"
+featured: false
+cover_image: ""
+price: "Gratuito"
+---
+
+Codelab presencial do programa Build with AI, organizado pelo GDG Lauro de Freitas, com foco em codelabs praticos sobre tecnologias Google, Gemini, cloud e experiencia de produto AI-first. A agenda e direcionada a desenvolvedores, designers e entusiastas de tecnologia.

--- a/src/content/events/build-with-ai-hands-on-codelab-experience.md
+++ b/src/content/events/build-with-ai-hands-on-codelab-experience.md
@@ -16,7 +16,7 @@ categories:
   - "cloud"
   - "ux"
 featured: false
-cover_image: ""
+cover_image: "https://res.cloudinary.com/startup-grind/image/upload/c_scale,w_2560/c_crop,h_640,w_2560,y_0.0_mul_h_sub_0.0_mul_640/c_crop,h_640,w_2560/c_fill,dpr_2.0,f_auto,g_center,q_auto:good/v1/gcs/platform-data-goog/event_banners/blob_4gIUTOG"
 price: "Gratuito"
 ---
 


### PR DESCRIPTION
## Event intake manual

- Acao: adicionar evento
- Fonte: [GDG Lauro de Freitas](https://gdg.community.dev/events/details/google-gdg-lauro-de-freitas-presents-build-with-ai-hands-on-codelab-experience)
- Ticket URL: [https://gdg.community.dev/events/details/google-gdg-lauro-de-freitas-presents-build-with-ai-hands-on-codelab-experience](https://gdg.community.dev/events/details/google-gdg-lauro-de-freitas-presents-build-with-ai-hands-on-codelab-experience)
- Confianca: 100/100
- Categorias: `ia`, `cloud`, `ux`
- Arquivo: `src/content/events/build-with-ai-hands-on-codelab-experience.md`

## Validacao

- Fonte publica informada no payload manual
- Evento marcado como tech direto
- Schema normalizado para o modelo editorial atual

<!-- event-intake-source:https://gdg.community.dev/events/details/google-gdg-lauro-de-freitas-presents-build-with-ai-hands-on-codelab-experience -->