### PR TITLE
feat(events): add Nullbyte Security Conference 2026

### DIFF
--- a/src/content/events/nullbyte-security-conference-2026.md
+++ b/src/content/events/nullbyte-security-conference-2026.md
@@ -1,0 +1,21 @@
+---
+title: "Nullbyte Security Conference 2026"
+start_date: "2026-11-07"
+end_date: "2026-11-07"
+kind: "conference"
+format: "in-person"
+city: "Salvador"
+state: "BA"
+organizer: "Nullbyte Security Conference"
+venue: "Saladearte Cinema do Museu"
+ticket_url: "https://nullbyte-con.org/"
+source_name: "Nullbyte Security Conference"
+source_url: "https://nullbyte-con.org/"
+categories: 
+  - "seguranca"
+featured: false
+cover_image: ""
+price: "R$ 250,00"
+---
+
+Conferencia tecnica de seguranca ofensiva em Salvador, com foco em pesquisas avancadas, hacking, exploracao, engenharia reversa, cloud attacks, aplicacoes modernas, hardware e IA aplicada a ofensiva. A edicao 2026 acontece em 7 de novembro no Saladearte Cinema do Museu.

--- a/src/content/events/nullbyte-security-conference-2026.md
+++ b/src/content/events/nullbyte-security-conference-2026.md
@@ -8,13 +8,13 @@ city: "Salvador"
 state: "BA"
 organizer: "Nullbyte Security Conference"
 venue: "Saladearte Cinema do Museu"
-ticket_url: "https://nullbyte-con.org/"
+ticket_url: "https://www.sympla.com.br/evento/nullbyte-security-conference-2026/3385269"
 source_name: "Nullbyte Security Conference"
-source_url: "https://nullbyte-con.org/"
+source_url: "https://www.sympla.com.br/evento/nullbyte-security-conference-2026/3385269"
 categories: 
   - "seguranca"
 featured: false
-cover_image: ""
+cover_image: "https://images.sympla.com.br/63ff553c07ff1.png"
 price: "R$ 250,00"
 ---
 


### PR DESCRIPTION
## Event intake manual

- Acao: adicionar evento
- Fonte: [Nullbyte Security Conference](https://nullbyte-con.org/)
- Ticket URL: [https://nullbyte-con.org/](https://nullbyte-con.org/)
- Confianca: 100/100
- Categorias: `seguranca`
- Arquivo: `src/content/events/nullbyte-security-conference-2026.md`

## Validacao

- Fonte publica informada no payload manual
- Evento marcado como tech direto
- Schema normalizado para o modelo editorial atual

<!-- event-intake-source:https://nullbyte-con.org/ -->