### PR TITLE
feat(events): add Palestra: Marketing na Era da IA | Palmeira dos Indios

### DIFF
--- a/src/content/events/palestra-marketing-na-era-da-ia-palmeira-dos-indios.md
+++ b/src/content/events/palestra-marketing-na-era-da-ia-palmeira-dos-indios.md
@@ -1,0 +1,26 @@
+---
+title: "Palestra: Marketing na Era da IA | Palmeira dos Indios"
+start_date: "2026-05-27"
+end_date: "2026-05-27"
+kind: "workshop"
+format: "in-person"
+city: "Palmeira dos Índios"
+state: "AL"
+organizer: "Sebrae Alagoas"
+venue: "Cesmac do Sertão"
+ticket_url: "https://doity.com.br/palestra-marketing-na-era-da-ia"
+source_name: "Doity Eventos"
+source_url: "https://doity.com.br/palestra-marketing-na-era-da-ia"
+categories: 
+  - "ia"
+  - "outros"
+featured: false
+cover_image: "https://grcmlesydpcd.objectstorage.sa-saopaulo-1.oci.customer-oci.com/p/OQwcvnO-c63O08Gc2Kv4OTbJttj5ik60dguiDIyyQ0wuo5SWn-jHOLW9wNbylNqI/n/grcmlesydpcd/b/dtysppobjmntbkp01/o/media/doity/eventos/evento-290584-banner.jpeg"
+price: "Gratuito"
+---
+
+Palestra sobre Marketing na Era da Inteligência Artificial.
+
+Data: Quarta, 27 de maio de 2026
+Horário: Das 19:00 às 21:00
+Local: Cesmac do Sertão, Palmeira dos Índios, AL


### PR DESCRIPTION
## Event intake

- Fonte: [Doity Eventos](https://doity.com.br/palestra-marketing-na-era-da-ia)
- Ticket URL: [https://doity.com.br/palestra-marketing-na-era-da-ia](https://doity.com.br/palestra-marketing-na-era-da-ia)
- Confianca: 100/100
- Datas: 2026-05-27 -> 2026-05-27
- Organizador: Sebrae Alagoas
- Categorias: `ia`, `outros`
- Relevancia tech: direct
- Publico tech: mixed
- Topicos tech: `ia`, `marketing`
- Evidencias tech: Marketing na Era da IA, IA

## Resumo

Palestra sobre Marketing na Era da Inteligência Artificial em Palmeira dos Índios, AL, organizada pelo Sebrae Alagoas. O evento ocorrerá no dia 27 de maio de 2026, das 19h às 21h, no Cesmac do Sertão.

## Ambiguidades

- nenhuma

<!-- event-intake-source:bbbe7aa2376f6ae74bd4697acf3f27943d1222beca5995a23c7d01edbda7ce18 -->