### PR TITLE
feat(events): add JustData Meetup Day Natal/RN — Powered by Mesha

### DIFF
--- a/src/content/events/justdata-meetup-day-natal-rn-powered-by-mesha.md
+++ b/src/content/events/justdata-meetup-day-natal-rn-powered-by-mesha.md
@@ -1,0 +1,28 @@
+---
+title: "JustData Meetup Day Natal/RN — Powered by Mesha"
+start_date: "2026-05-29"
+end_date: "2026-05-29"
+kind: "meetup"
+format: "in-person"
+city: "Natal"
+state: "RN"
+organizer: "Justdata"
+venue: "SEBRAELABS"
+ticket_url: "https://doity.com.br/justdata-meetup-day-natalrn"
+source_name: "Doity Eventos"
+source_url: "https://doity.com.br/justdata-meetup-day-natalrn"
+categories: 
+  - "data-science"
+featured: false
+cover_image: "https://grcmlesydpcd.objectstorage.sa-saopaulo-1.oci.customer-oci.com/p/OQwcvnO-c63O08Gc2Kv4OTbJttj5ik60dguiDIyyQ0wuo5SWn-jHOLW9wNbylNqI/n/grcmlesydpcd/b/dtysppobjmntbkp01/o/media/doity/fb001122.png"
+price: "Gratuito"
+---
+
+Encontro presencial da comunidade com foco em carreira em dados. O meetup abordará o cenário atual da área, caminhos profissionais, desafios do mercado, aprendizado contínuo e experiências de profissionais. O objetivo é criar um ambiente colaborativo para trocas entre participantes e convidados.
+
+Realização: JustData
+Powered by: Mesha
+Local: SEBRAELAB Natal/RN
+Data: 29 de Maio
+Horário: 18h30
+Vagas limitadas: 35 participantes


### PR DESCRIPTION
## Event intake

- Fonte: [Doity Eventos](https://doity.com.br/justdata-meetup-day-natalrn)
- Ticket URL: [https://doity.com.br/justdata-meetup-day-natalrn](https://doity.com.br/justdata-meetup-day-natalrn)
- Confianca: 100/100
- Datas: 2026-05-29 -> 2026-05-29
- Organizador: Justdata
- Categorias: `data-science`
- Relevancia tech: direct
- Publico tech: mixed
- Topicos tech: `data-science`, `carreira em dados`
- Evidencias tech: mercado de dados, profissionais da área, carreira em dados

## Resumo

JustData Meetup Day em Natal/RN, um encontro presencial focado em carreira em dados. Discutirá o mercado, aprendizado e experiências com profissionais. Evento gratuito com vagas limitadas.

## Ambiguidades

- nenhuma

<!-- event-intake-source:8156786c37cda0ae5861cc62cd5463c591d2968732df35d38bf5a0bf85a61736 -->