### PR TITLE
feat(events): add Google I/O Extended João Pessoa

### DIFF
--- a/src/content/events/google-i-o-extended-joao-pessoa.md
+++ b/src/content/events/google-i-o-extended-joao-pessoa.md
@@ -1,0 +1,23 @@
+---
+title: "Google I/O Extended João Pessoa"
+start_date: "2026-07-18"
+end_date: "2026-07-18"
+kind: "other"
+format: "in-person"
+city: "Cabedelo"
+state: "PB"
+organizer: "Google Developer Groups"
+venue: "Centro Universitário - UNIESP"
+ticket_url: "https://gdgjoaopessoa.com.br/google-io-extended"
+source_name: "GDG Joao Pessoa"
+source_url: "https://gdg.community.dev/events/details/google-gdg-joao-pessoa-presents-google-io-extended-joao-pessoa-2"
+categories: 
+  - "cloud"
+  - "ia"
+  - "mobile"
+featured: false
+cover_image: "https://res.cloudinary.com/startup-grind/image/upload/c_fill,dpr_2.0,f_auto,g_center,h_1080,q_100,w_1080/v1/gcs/platform-data-goog/event_banners/GDG_Bevy_DefaultEventThumbnail_2_MF2GjYZ.png"
+price: ""
+---
+
+Junte-se a nós no Google I/O Extended João Pessoa, uma excelente oportunidade para se aprofundar nos mais recentes avanç...


### PR DESCRIPTION
## Event intake

- Fonte: [GDG Joao Pessoa](https://gdg.community.dev/events/details/google-gdg-joao-pessoa-presents-google-io-extended-joao-pessoa-2)
- Ticket URL: [https://gdgjoaopessoa.com.br/google-io-extended](https://gdgjoaopessoa.com.br/google-io-extended)
- Confianca: 100/100
- Datas: 2026-07-18 -> 2026-07-18
- Organizador: Google Developer Groups
- Categorias: `cloud`, `ia`, `mobile`
- Relevancia tech: direct
- Publico tech: tech
- Topicos tech: `cloud`, `ia`, `mobile`
- Evidencias tech: developer, android, cloud, firebase, ai

## Resumo

Junte-se a nós no Google I/O Extended João Pessoa, uma excelente oportunidade para se aprofundar nos mais recentes avanç...

## Ambiguidades

- nenhuma

<!-- event-intake-source:1baefee5cbb148a2ac5697aebb7d43a07bf6982422b8feb166f3462ae1528234 -->